### PR TITLE
Improve docker connection error

### DIFF
--- a/ci/main.snek
+++ b/ci/main.snek
@@ -1,3 +1,4 @@
+/*
 rust = Image("rustlang/rust:nightly");
 src = rust 
     > WorkingDir("/app") 
@@ -30,3 +31,10 @@ checks = !(tests, spelling, clippy, fmt) Noop(0);
 build = src > !checks Exec("cargo build --release");
 
 export DEFAULT = build;
+*/
+
+export DEFAULT = Image("rustlang/rust:nightly")
+    > WorkingDir("/app")
+    > With(FromHost("."), ".")
+    > Exec("cargo run -- --pipeline ci/main.snek"); // Recursion :O
+

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -37,7 +37,11 @@ pub struct DockerClient {
 impl DockerClient {
     /// Create a new Docker client
     pub async fn new(tui: TuiSender) -> Result<Self, RuntimeError> {
-        let client = Self::connect_docker().await?;
+        let client = Self::connect_docker()
+            .await
+            .map_err(|err| RuntimeError::DockerNotFound {
+                inner: Box::new(err),
+            })?;
         Ok(Self {
             client,
             containers: RefCell::new(HashMap::new()),

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -15,9 +15,21 @@ use crate::tui::{TuiMessage, TuiSender};
 #[derive(Debug, Error, Diagnostic)]
 pub enum RuntimeError {
     /// A Docker API error
-    #[error("Docker API error: {0}")]
+    #[error("Container API error: {0}")]
     #[diagnostic(code(docker_error))]
     Docker(#[from] bollard::errors::Error),
+
+    /// Error establishing connection to docker/podman
+    #[error("Docker/Podman not found")]
+    #[diagnostic(code(docker_not_found))]
+    #[diagnostic(help(
+        "If docker or podman is installed try setting `DOCKER_HOST` environment variable explicitly."
+    ))]
+    DockerNotFound {
+        /// The inner error
+        #[diagnostic_source]
+        inner: Box<dyn Diagnostic + Send + Sync>,
+    },
 
     /// A command failed to execute
     #[error("Failed to execute command (exit code {code}): {command:?} \n{output}")]
@@ -36,7 +48,7 @@ pub enum RuntimeError {
     ExecParse(#[from] shell_words::ParseError),
 
     /// A filesystem read error
-    #[error("Io error")]
+    #[error("Io error: {0}")]
     #[diagnostic(code(filesystem_read_error))]
     IoError(#[from] std::io::Error),
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,7 @@ enum SerpentineError {
 
     /// Something failed at runtime.
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Runtime(engine::RuntimeError),
 }
 

--- a/src/snek/mod.rs
+++ b/src/snek/mod.rs
@@ -183,15 +183,6 @@ pub enum CompileError {
         location: Span,
     },
 
-    /// The entry point label wasnt found
-    #[error("Entry point '{name}' not found")]
-    #[diagnostic(code(compiler::entrypoint_not_found))]
-    #[diagnostic(help("Make sure its exported."))]
-    EntryPointNotFound {
-        /// The name of the entry point
-        name: String,
-    },
-
     /// A circular import was encountered.
     #[error("Circular import. Module {file} attempted to be imported while resolving.")]
     #[diagnostic(code(compiler::circular_import))]


### PR DESCRIPTION
Docker connection errors now render as:
```
Error: docker_not_found

  × Docker/Podman not found
  ├─▶ filesystem_read_error
  │   
  │     × Io error: No such file or directory (os error 2)
  │   
  ╰─▶ No such file or directory (os error 2)
  help: If docker or podman is installed try setting `DOCKER_HOST` environment variable explicitly.
```
Instead of just the inner error (in this case simply a `No such file or directory (os error 2)`)