### PR TITLE
Add ShellEscape node for safe string escaping in shell commands

### DIFF
--- a/serpentine_internal/src/nodes/README.md
+++ b/serpentine_internal/src/nodes/README.md
@@ -1,0 +1,33 @@
+# Nodes
+
+This module contains implementations of the built-in nodes used in serpentine pipelines.
+
+## ShellEscape
+
+The `ShellEscape` node accepts a single string input and outputs a version escaped according to POSIX shell rules for safe use in shell commands. It wraps the string in single quotes and escapes internal single quotes using the `\''` sequence.
+
+This prevents shell injection vulnerabilities when combining strings in `Exec` nodes.
+
+### Example
+
+```rust
+use serpentine_internal::nodes::{ShellEscape, Node, Value, Context};
+use serpentine_internal::value::Type;
+
+let node = ShellEscape;
+let inputs = vec![Value::String("It's a test!".to_string())];
+let ctx = Context::default();
+let output = node.run(&inputs, &ctx).unwrap();
+
+assert_eq!(
+    output[0].as_string().unwrap(),
+    "'It'\''s a test!'"
+);
+```
+
+### Demonstrated Cases
+
+- Empty string: `''`
+- String with spaces: `'hello world'`
+- String with single quote: `'o'\''reilly'`
+- String with newline: `'hello\nworld'` (newlines are preserved within quotes)

--- a/serpentine_internal/src/nodes/mod.rs
+++ b/serpentine_internal/src/nodes/mod.rs
@@ -1,0 +1,14 @@
+//! Module containing all built-in nodes for serpentine.
+
+pub mod shell_escape;
+
+pub use shell_escape::ShellEscape;
+
+// TODO: Add to node registry if not already handled elsewhere.
+// For example:
+// pub fn create_node(name: &str) -> Option<Box<dyn Node>> {
+//     match name {
+//         "shell_escape" => Some(Box::new(ShellEscape)),
+//         _ => None,
+//     }
+// }

--- a/serpentine_internal/src/nodes/shell_escape.rs
+++ b/serpentine_internal/src/nodes/shell_escape.rs
@@ -1,0 +1,71 @@
+use crate::nodes::{Node, Value, Error, Type, Context};
+
+#[derive(Clone, Debug, Default)]
+pub struct ShellEscape;
+
+impl Node for ShellEscape {
+    fn name(&self) -> &'static str {
+        "shell_escape"
+    }
+
+    fn input_types(&self) -> &'static [Type] {
+        &[Type::String]
+    }
+
+    fn output_types(&self) -> &'static [Type] {
+        &[Type::String]
+    }
+
+    fn run(&self, inputs: &[Value], _ctx: &Context) -> Result<Vec<Value>, Error> {
+        if inputs.len() != 1 {
+            return Err(Error::InvalidNumberOfInputs { expected: 1, got: inputs.len() });
+        }
+        match &inputs[0] {
+            Value::String(s) => {
+                let inner = s.replace("'", "'\\''");
+                let result = format!("'{inner}'");
+                Ok(vec![Value::String(result)])
+            }
+            _ => Err(Error::InvalidInputType { expected: Type::String, got: inputs[0].type_() }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::Context;
+    use crate::value::{Type, Value};
+
+    #[test]
+    fn empty_string() {
+        let node = ShellEscape;
+        let inputs = vec![Value::String(String::new())];
+        let output = node.run(&inputs, &Context::default()).unwrap();
+        assert_eq!(output, vec![Value::String("''".to_string())]);
+    }
+
+    #[test]
+    fn string_with_spaces() {
+        let node = ShellEscape;
+        let inputs = vec![Value::String("hello world".to_string())];
+        let output = node.run(&inputs, &Context::default()).unwrap();
+        assert_eq!(output, vec![Value::String("'hello world'".to_string())]);
+    }
+
+    #[test]
+    fn string_with_single_quote() {
+        let node = ShellEscape;
+        let inputs = vec![Value::String("o'reilly".to_string())];
+        let output = node.run(&inputs, &Context::default()).unwrap();
+        assert_eq!(output, vec![Value::String("'o'\''reilly'".to_string())]);
+    }
+
+    #[test]
+    fn string_with_newline() {
+        let node = ShellEscape;
+        let inputs = vec![Value::String("hello\nworld".to_string())];
+        let output = node.run(&inputs, &Context::default()).unwrap();
+        assert_eq!(output, vec![Value::String("'hello\\nworld'".to_string())]);
+    }
+}


### PR DESCRIPTION
Add a new `ShellEscape` node that takes a string input and produces a safe, POSIX-compliant shell-escaped output. This uses single quotes around the string and properly escapes any internal single quotes to prevent shell injection attacks in command construction (e.g., replacing `Exec` + `Join` patterns).

The implementation includes a helper for escaping and handles the empty string case. A unit test suite covers common scenarios: empty strings, spaces, single quotes, and newlines. A brief example is added to the nodes README.

Fixes #50