### PR TITLE
add string escapes

### DIFF
--- a/book/src/snek.md
+++ b/book/src/snek.md
@@ -207,3 +207,7 @@ flowchart LR
 
 This becomes even more important with Functions take our `Binstall` function from before, without this optimization every call to it would install binstall and the given tool every time, but with the de-duplicator binstall is only installed once, and each specific tool is also only installed once.
 This means you can write functions as ergonomicly as you want and as long as you are smart with at which points you introduce the arguments you can still get amazing performance.
+
+## String escapes
+Snek also supports a small number of string escapes, mainly `\\`, `\"`, other unknown escapes are inserted directly, allowing `sh` to handle them. 
+

--- a/serpentine/src/main.rs
+++ b/serpentine/src/main.rs
@@ -355,7 +355,7 @@ mod tests {
             insta::with_settings! { {
                 filters => vec![
                     // Redact file paths
-                    (r#"(?:\\\\[?.]\\)?(?:[A-Za-z]:)?(?:[/\\][^/\\\s:"'\]]+)+"#, "<redacted-path>"),
+                    (r#"(?:\\\\[?.]\\)?(?:[A-Za-z]:)?(?:[/\\][^/\\\s:"'\]]+){2,}"#, "<redacted-path>"),
                     // Redact OS error messages, they can be different on different systems
                     (r"(?i)os error \d+: [^\n]+", "OS error <redacted>"),
                 ],

--- a/serpentine/src/snek/mod.rs
+++ b/serpentine/src/snek/mod.rs
@@ -272,7 +272,7 @@ mod tests {
                 insta::with_settings! { {
                     filters => vec![
                         // Redact file paths
-                        (r#"(?:\\\\[?.]\\)?(?:[A-Za-z]:)?(?:[/\\][^/\\\s:"'\]]+)+"#, "<redacted-path>"),
+                        (r#"(?:\\\\[?.]\\)?(?:[A-Za-z]:)?(?:[/\\][^/\\\s:"'\]]+){2,}"#, "<redacted-path>"),
                         // Redact OS error messages, they can be different on different systems
                         (r"(?i)os error \d+: [^\n]+", "OS error <redacted>"),
                     ],

--- a/serpentine/src/snek/resolver.rs
+++ b/serpentine/src/snek/resolver.rs
@@ -437,7 +437,7 @@ impl<'arena> Resolver<'arena> {
             })?;
 
         let file_id = self.file.push(module.to_owned(), code);
-        let tokens = super::tokenizer::Tokenizer::tokenize(file_id, code)?;
+        let tokens = super::tokenizer::Tokenizer::tokenize(self.arena, file_id, code)?;
         let ast = super::parser::Parser::parse_file(tokens)?;
 
         let mut exports = Scope::root();

--- a/serpentine/src/snek/snapshots/serpentine__snek__tests__error_in_import.snek.snap
+++ b/serpentine/src/snek/snapshots/serpentine__snek__tests__error_in_import.snek.snap
@@ -1,5 +1,5 @@
 ---
-source: src/snek/mod.rs
+source: serpentine/src/snek/mod.rs
 expression: err
 ---
   x Compile Error
@@ -18,7 +18,7 @@ Error:
          `----
       
    ,-[<redacted-path>:1:8]
- 1 | import ".<redacted-path>" as lib;
+ 1 | import "./double_return.snek" as lib;
    :        ^^^^^^^^^^^|^^^^^^^^^^
    :                   `-- In this import statement
  2 | 

--- a/serpentine/src/snek/snapshots/serpentine__snek__tests__export_import_in_function.snek.snap
+++ b/serpentine/src/snek/snapshots/serpentine__snek__tests__export_import_in_function.snek.snap
@@ -1,5 +1,5 @@
 ---
-source: src/snek/mod.rs
+source: serpentine/src/snek/mod.rs
 expression: err
 ---
   x Compile Error
@@ -13,7 +13,7 @@ Error:
   `-> No such file or directory (os error 2)
    ,-[<redacted-path>:2:19]
  1 | def Foo() {
- 2 |     export import "..<redacted-path>" as lib;
+ 2 |     export import "../lib.snek" as lib;
    :                   ^^^^^^|^^^^^^
    :                         `-- In this import statement
  3 |     return Image("rust:latest");

--- a/serpentine/src/snek/snapshots/serpentine__snek__tests__item_not_found_import.snek.snap
+++ b/serpentine/src/snek/snapshots/serpentine__snek__tests__item_not_found_import.snek.snap
@@ -1,5 +1,5 @@
 ---
-source: src/snek/mod.rs
+source: serpentine/src/snek/mod.rs
 expression: err
 ---
   x Compile Error
@@ -12,7 +12,7 @@ Error:
   |   
   `-> No such file or directory (os error 2)
    ,-[<redacted-path>:1:8]
- 1 | import "..<redacted-path>" as lib;
+ 1 | import "../lib.snek" as lib;
    :        ^^^^^^|^^^^^^
    :              `-- In this import statement
  2 | 

--- a/serpentine/src/snek/snapshots/serpentine__snek__tests__recursive_import_1.snek.snap
+++ b/serpentine/src/snek/snapshots/serpentine__snek__tests__recursive_import_1.snek.snap
@@ -1,5 +1,5 @@
 ---
-source: src/snek/mod.rs
+source: serpentine/src/snek/mod.rs
 expression: err
 ---
   x Compile Error
@@ -8,7 +8,7 @@ Error:
   x Importing module '<redacted-path>' failed
   |->   x Importing module '<redacted-path>' failed
   |      ,-[<redacted-path>:1:8]
-  |    1 | import ".<redacted-path>" as lib;
+  |    1 | import "./recursive_import_1.snek" as lib;
   |      :        ^^^^^^^^^^^^^|^^^^^^^^^^^^^
   |      :                     `-- In this import statement
   |      `----
@@ -18,7 +18,7 @@ Error:
         x Circular import. Module <redacted-path> attempted to be imported while resolving.
       
    ,-[<redacted-path>:1:8]
- 1 | import ".<redacted-path>" as lib;
+ 1 | import "./recursive_import_2.snek" as lib;
    :        ^^^^^^^^^^^^^|^^^^^^^^^^^^^
    :                     `-- In this import statement
    `----

--- a/serpentine/src/snek/snapshots/serpentine__snek__tests__recursive_import_2.snek.snap
+++ b/serpentine/src/snek/snapshots/serpentine__snek__tests__recursive_import_2.snek.snap
@@ -1,5 +1,5 @@
 ---
-source: src/snek/mod.rs
+source: serpentine/src/snek/mod.rs
 expression: err
 ---
   x Compile Error
@@ -8,7 +8,7 @@ Error:
   x Importing module '<redacted-path>' failed
   |->   x Importing module '<redacted-path>' failed
   |      ,-[<redacted-path>:1:8]
-  |    1 | import ".<redacted-path>" as lib;
+  |    1 | import "./recursive_import_2.snek" as lib;
   |      :        ^^^^^^^^^^^^^|^^^^^^^^^^^^^
   |      :                     `-- In this import statement
   |      `----
@@ -18,7 +18,7 @@ Error:
         x Circular import. Module <redacted-path> attempted to be imported while resolving.
       
    ,-[<redacted-path>:1:8]
- 1 | import ".<redacted-path>" as lib;
+ 1 | import "./recursive_import_1.snek" as lib;
    :        ^^^^^^^^^^^^^|^^^^^^^^^^^^^
    :                     `-- In this import statement
    `----

--- a/serpentine/src/snek/snapshots/serpentine__snek__tests__unexpected_eof.snek.snap
+++ b/serpentine/src/snek/snapshots/serpentine__snek__tests__unexpected_eof.snek.snap
@@ -1,0 +1,14 @@
+---
+source: serpentine/src/snek/mod.rs
+expression: err
+---
+  x Compile Error
+
+Error: parsing::unexpected_token
+
+  x Expected `identifier`
+   ,-[<redacted-path>:1:13]
+ 1 | export foo =
+   :             |
+   :             `-- Got `end of file`
+   `----

--- a/serpentine/src/snek/snapshots/serpentine__snek__tests__unterminted_string.snek.snap
+++ b/serpentine/src/snek/snapshots/serpentine__snek__tests__unterminted_string.snek.snap
@@ -1,0 +1,14 @@
+---
+source: serpentine/src/snek/mod.rs
+expression: err
+---
+  x Compile Error
+
+Error: parsing::unterminated_string
+
+  x Unterminated string literal
+   ,-[<redacted-path>:1:20]
+ 1 | export foo = Image("rust:latest);
+   :                    ^^^^^^^|^^^^^^^
+   :                           `-- String literal not terminated
+   `----

--- a/serpentine/src/snek/tokenizer.rs
+++ b/serpentine/src/snek/tokenizer.rs
@@ -75,6 +75,8 @@ impl Token<'_> {
 
 /// the tokenizer handles turning a input stream into tokens
 pub struct Tokenizer<'arena> {
+    /// The arena to allocate token data in
+    arena: &'arena bumpalo::Bump,
     /// File id for the file
     file_id: FileId,
     /// The code to parse into tokens
@@ -86,10 +88,12 @@ pub struct Tokenizer<'arena> {
 impl<'arena> Tokenizer<'arena> {
     /// tokenize the given string and return the spanned tokens
     pub fn tokenize(
+        arena: &'arena bumpalo::Bump,
         file_id: FileId,
         code: &'arena str,
     ) -> Result<Box<[Spanned<Token<'arena>>]>, CompileError> {
         let mut tokenizer = Self {
+            arena,
             file_id,
             code,
             byte: 0,
@@ -126,19 +130,7 @@ impl<'arena> Tokenizer<'arena> {
                 self.advance()?;
                 self.span(2).with(Token::Path)
             }
-            '"' => {
-                let consumed = self.advance_while(|next_char| next_char != '"')?;
-                let content_span = self.span(consumed);
-                if self.advance()?.is_none() {
-                    return Err(CompileError::UnterminatedString {
-                        location: content_span,
-                    });
-                }
-                let string_span = self.span(consumed.saturating_add(2));
-
-                let content = content_span.index_str(self.code)?;
-                string_span.with(Token::String(content))
-            }
+            '"' => self.handle_string()?,
             '/' if self.peek()? == Some('/') => {
                 // consume until end of line
                 self.advance()?;
@@ -199,11 +191,53 @@ impl<'arena> Tokenizer<'arena> {
         }))
     }
 
-    /// Consume characters that satifisy the predicate, returning the number of bytes consumed
-    pub fn advance_while(
-        &mut self,
-        predicate: impl Fn(char) -> bool,
-    ) -> Result<usize, CompileError> {
+    /// Handle the tokenization of a string
+    fn handle_string(&mut self) -> Result<Spanned<Token<'arena>>, CompileError> {
+        enum ParsingState {
+            Normal,
+            Escape,
+        }
+
+        let mut consumed = 1_usize; // initial "
+        let mut content = bumpalo::collections::String::new_in(self.arena);
+        let mut state = ParsingState::Normal;
+
+        loop {
+            if let Some(next_char) = self.advance()? {
+                consumed = consumed.saturating_add(next_char.len_utf8());
+
+                match state {
+                    ParsingState::Normal => match next_char {
+                        '"' => break,
+                        '\\' => state = ParsingState::Escape,
+                        _ => content.push(next_char),
+                    },
+                    ParsingState::Escape => {
+                        let escaped_char = match next_char {
+                            '\\' => '\\',
+                            '"' => '"',
+                            other => {
+                                content.push('\\');
+                                other
+                            }
+                        };
+                        content.push(escaped_char);
+                        state = ParsingState::Normal;
+                    }
+                }
+            } else {
+                return Err(CompileError::UnterminatedString {
+                    location: self.span(consumed),
+                });
+            }
+        }
+
+        let string_span = self.span(consumed);
+        Ok(string_span.with(Token::String(content.into_bump_str())))
+    }
+
+    /// Consume characters that satisfy the predicate, returning the number of bytes consumed
+    fn advance_while(&mut self, predicate: impl Fn(char) -> bool) -> Result<usize, CompileError> {
         let mut consumed: usize = 0;
         while let Some(next_character) = self.peek()?
             && predicate(next_character)
@@ -244,7 +278,7 @@ impl<'arena> Tokenizer<'arena> {
 }
 
 #[cfg(test)]
-#[expect(clippy::expect_used, reason = "tests")]
+#[expect(clippy::expect_used, clippy::panic, reason = "tests")]
 mod tests {
     use proptest::property_test;
     use rstest::rstest;
@@ -254,20 +288,44 @@ mod tests {
 
     #[property_test]
     fn doesnt_panic(code: String) {
-        let _ = Tokenizer::tokenize(FileId(0), &code);
+        let _ = Tokenizer::tokenize(&bumpalo::Bump::new(), FileId(0), &code);
     }
 
     #[rstest]
     #[case::simple_number("123")]
     #[case::string(r#""hello""#)]
     fn tokenize(#[case] code: String) {
-        let res = Tokenizer::tokenize(FileId(0), &code);
+        let arena = bumpalo::Bump::new();
+        let res = Tokenizer::tokenize(&arena, FileId(0), &code);
         assert!(res.is_ok(), "Failed to tokenize {code:?}: {res:?}");
+    }
+
+    #[rstest]
+    #[case::simple(r#""hello""#, "hello")]
+    #[case::backslash(r#""hello\\nworld""#, r"hello\nworld")]
+    #[case::quote(r#""hello\"world""#, r#"hello"world"#)]
+    #[case::quote_start(r#""\"hello""#, r#""hello"#)]
+    #[case::quote_end(r#""hello\"""#, r#"hello""#)]
+    #[case::unknown_escape(r#""\v""#, r"\v")]
+    fn string_parsing(#[case] code: String, #[case] expected: String) {
+        let arena = bumpalo::Bump::new();
+        let res = Tokenizer::tokenize(&arena, FileId(0), &code).expect("Failed to tokenize");
+
+        assert_eq!(res.len(), 2, "Expected 2 tokens, string, EOF");
+        let Some(string_token) = res.first() else {
+            panic!("Expected first token to be a string, got EOF");
+        };
+
+        assert!(
+            matches!(string_token.take(), Token::String(value) if value == expected),
+            "Expected first token to be a string with value {expected:?}, got {string_token:?}",
+        );
     }
 
     #[test]
     fn empty_comment() {
-        let res = Tokenizer::tokenize(FileId(0), "/**/123").expect("Failed to tokenize");
+        let arena = bumpalo::Bump::new();
+        let res = Tokenizer::tokenize(&arena, FileId(0), "/**/123").expect("Failed to tokenize");
         assert_eq!(res.len(), 2, "Expected 2 tokens, number, EOF");
     }
 
@@ -277,7 +335,8 @@ mod tests {
     #[case::single_colon(":")]
     #[case::double_colon_with_whitespace(": :")]
     fn edge_case_fails(#[case] code: String) {
-        let res = Tokenizer::tokenize(FileId(0), &code);
+        let arena = bumpalo::Bump::new();
+        let res = Tokenizer::tokenize(&arena, FileId(0), &code);
         assert!(res.is_err(), "Should fail to tokenize {code:?}: {res:?}");
     }
 }

--- a/test_cases/live/string_escapes.snek
+++ b/test_cases/live/string_escapes.snek
@@ -1,0 +1,5 @@
+image = Image("quay.io/toolbx-images/alpine-toolbox:3.21@sha256:ff9f4d34ce354d6be4c8fc551ebb1bb57c5941df4b42c970b9852f3744fb6bf0");
+
+export DEFAULT = image
+    > Exec("test $(echo \"hello\") = hello")
+    > Exec("test $(printf 'a\nb\n' | wc -l) = 2");

--- a/test_cases/negative/parser/unexpected_eof.snek
+++ b/test_cases/negative/parser/unexpected_eof.snek
@@ -1,0 +1,1 @@
+export foo =

--- a/test_cases/negative/parser/unterminted_string.snek
+++ b/test_cases/negative/parser/unterminted_string.snek
@@ -1,0 +1,1 @@
+export foo = Image("rust:latest);

--- a/test_cases/positive/unknown_escape.snek
+++ b/test_cases/positive/unknown_escape.snek
@@ -1,0 +1,1 @@
+export DEFAULT = Image("rust:latest\v");


### PR DESCRIPTION
closes #46 

This mainly covers `\\` and `\"`, and a few common ones, as since we use `sh` anything not directly supported can done via `printf` or similar