### PR TITLE
collapse renovate update groups

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -108,38 +108,7 @@
   ],
   "packageRules": [
     {
-      "matchManagers": [
-        "github-actions"
-      ],
-      "groupName": "github actions"
-    },
-    {
-      "matchManagers": [
-        "cargo"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "groupName": "cargo (minor/patch)"
-    },
-    {
-      "matchFileNames": [
-        "Dockerfile",
-        "ci/**"
-      ],
-      "groupName": "container base images"
-    },
-    {
-      "matchFileNames": [
-        "Dockerfile",
-        "ci/**",
-        ".github/workflows/**"
-      ],
-      "matchDatasources": [
-        "crate"
-      ],
-      "groupName": "ci tooling"
+      "groupName": "dependencies"
     },
     {
       "matchFileNames": [


### PR DESCRIPTION
Bumps get merged as one batch in practice, so splitting them by area only multiplied CI runs. Test fixture images stay separate because they arrive red until the snapshots are regenerated, and renovate splits majors out on its own.